### PR TITLE
Adding jira issue to branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It helps to reduce the amount of time spent on creating/managing git branches th
 
 ### List of all supported flags
 - `got -b XXXX` - creates new git branch with the name generated from Jira issue. If the branch already exists (locally or remotely) then it will switch to it.
+- `got -ab XXXX` - links Jira issue to the current branch if not linked already
 - `got -cj` - creates a new Jira issue and if it succeeds creates new git branch for it
 - `got -m` - modifies Jira issue summary and current branch name
 - `got -info` - prints current branch Jira issues info

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func checkoutJiraBranch() {
 		return
 	}
 
-	branchName, err := git.FindBranchBySubstring(config.GetIssueKey())
+	branchName, err := git.FindBranchBySubstring(config.GetIssueKey() + config.Options.IssueBranchSeparator)
 	if err != nil {
 		printErrorToConsole(err)
 		return

--- a/main.go
+++ b/main.go
@@ -102,6 +102,12 @@ func modifyBranch() {
 		printErrorToConsole(err)
 		return
 	}
+	if len(issueKeys) == 0 {
+		printErrorToConsole(fmt.Errorf(
+			"Branch name '%s' does not contain issue keys with prefix '%s'", currentBranchName, config.GetIssueKeyPrefix(),
+		))
+		return
+	}
 
 	issueKey := issueKeys[0]
 
@@ -171,6 +177,12 @@ func printInfo() {
 	issueKeys, err := git.GetIssueKeysFromBranchName(currentBranchName)
 	if err != nil {
 		printErrorToConsole(err)
+		return
+	}
+	if len(issueKeys) == 0 {
+		printErrorToConsole(fmt.Errorf(
+			"Branch name '%s' does not contain issue keys with prefix '%s'", currentBranchName, config.GetIssueKeyPrefix(),
+		))
 		return
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,10 +14,11 @@ type OperationType string
 
 // CheckoutBranch is a holder of operation name
 const (
-	CheckoutBranch             OperationType = "CheckoutBranch"
-	ModifyBranch               OperationType = "ModifyBranch"
-	CheckBranchForNewJiraIssue OperationType = "CheckBranchForNewJiraIssue"
-	PrintInfo                  OperationType = "PrintInfo"
+	CheckoutBranch              OperationType = "CheckoutBranch"
+	ModifyBranch                OperationType = "ModifyBranch"
+	CheckBranchForNewJiraIssue  OperationType = "CheckBranchForNewJiraIssue"
+	PrintInfo                   OperationType = "PrintInfo"
+	AddJiraIssueToCurrentBranch OperationType = "AddJiraIssueToBranch"
 )
 
 // OptionsType is a type for stored app configuration
@@ -50,6 +51,7 @@ func InitAndRequestAdditionalData() error {
 	modifyBranch := flag.Bool("m", false, "Update branch name with Jira issue summary")
 	createIssue := flag.Bool("cj", false, "Create a new Jira issue and switch to the new branch")
 	printIssuesInfo := flag.Bool("info", false, "Print current branch Jira issues information")
+	issueCodeForLinking := flag.Int("ab", 0, "Links Jira Issue to current branch")
 	flag.Parse()
 
 	if *ticketID < 0 {
@@ -59,6 +61,12 @@ func InitAndRequestAdditionalData() error {
 	if *ticketID > 0 {
 		Options.IssueCode = *ticketID
 		Options.Operation = CheckoutBranch
+		return nil
+	}
+
+	if *issueCodeForLinking > 0 {
+		Options.Operation = AddJiraIssueToCurrentBranch
+		Options.IssueCode = *issueCodeForLinking
 		return nil
 	}
 

--- a/pkg/git/commands.go
+++ b/pkg/git/commands.go
@@ -69,8 +69,8 @@ func CheckoutNewBranch(branchName string) ([]byte, error) {
 	return output, nil
 }
 
-// UpdateBranchName updates current branch name
-func UpdateBranchName(branchName string) ([]byte, error) {
+// UpdateCurrentBranchName updates current branch name
+func UpdateCurrentBranchName(branchName string) ([]byte, error) {
 	cmd := exec.Command("git", "branch", "-m", branchName)
 	output, err := cmd.Output()
 	if err != nil {

--- a/pkg/git/utils.go
+++ b/pkg/git/utils.go
@@ -48,14 +48,7 @@ func GetIssueKeysFromBranchName(branchName string) ([]string, error) {
 		return strings.HasPrefix(substring, issueKeyPrefix)
 	}
 
-	issueKeys := filter(substrings, filterFunc)
-	if len(issueKeys) == 0 {
-		return nil, fmt.Errorf(
-			"Branch name '%s' does not contain issue keys with prefix '%s'", branchName, issueKeyPrefix,
-		)
-	}
-
-	return issueKeys, nil
+	return filter(substrings, filterFunc), nil
 }
 
 func filter(stringsArr []string, filterFunc func(string) bool) (filteredArr []string) {

--- a/pkg/git/utils.go
+++ b/pkg/git/utils.go
@@ -27,6 +27,13 @@ func GenerateBranchName(issueKeys []string, summary string) (string, error) {
 	return strings.Join(branchNameSubstrings, config.Options.IssueBranchSeparator), nil
 }
 
+// AddIssueKeysToBranchName add issue keys to branch name
+func AddIssueKeysToBranchName(issueKeys []string, branchName string) (string, error) {
+	branchNameSubstrings := append(issueKeys, branchName)
+
+	return strings.Join(branchNameSubstrings, config.Options.IssueBranchSeparator), nil
+}
+
 // GetIssueKeysFromBranchName returns list of Jira issue keys accosiated with current branch
 func GetIssueKeysFromBranchName(branchName string) ([]string, error) {
 	substrings := strings.Split(branchName, config.Options.IssueBranchSeparator)


### PR DESCRIPTION
## Sumary
Current PR adds flag '-ab XXXX' that links Jira issue to the current branch (without validation of Jira issue existence).
Also current PR fixes by with branch name search by issue code and refactors `git.GetIssueKeysFromBranchName` for better flexibility in further usage


## Checklist
- Checkout new branch `PC-22/test_branch_name`
- execute `got -ab 1234`
- it should update branch name to `PC-1234/test_branch_name`