### PR TITLE
Link jira issue to branch with -lj command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It helps to reduce the amount of time spent on creating/managing git branches th
 
 ### List of all supported flags
 - `got -b XXXX` - creates new git branch with the name generated from Jira issue. If the branch already exists (locally or remotely) then it will switch to it.
-- `got -ab XXXX` - links Jira issue to the current branch if not linked already
+- `got -lj XXXX` - links Jira issue to the current branch if not linked already
 - `got -cj` - creates a new Jira issue and if it succeeds creates new git branch for it
 - `got -m` - modifies Jira issue summary and current branch name
 - `got -info` - prints current branch Jira issues info

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ It helps to reduce the amount of time spent on creating/managing git branches th
 
 ### List of all supported flags
 - `got -b XXXX` - creates new git branch with the name generated from Jira issue. If the branch already exists (locally or remotely) then it will switch to it.
+- `got -ab XXXX` - links Jira issue to the current branch if not linked already
 - `got -cj` - creates a new Jira issue and if it succeeds creates new git branch for it
 - `got -m` - modifies Jira issue summary and current branch name
 - `got -info` - prints current branch Jira issues info

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func checkoutJiraBranch() {
 		return
 	}
 
-	branchName, err := git.FindBranchBySubstring(config.GetIssueKey())
+	branchName, err := git.FindBranchBySubstring(config.GetIssueKey() + config.Options.IssueBranchSeparator)
 	if err != nil {
 		printErrorToConsole(err)
 		return

--- a/main.go
+++ b/main.go
@@ -23,8 +23,8 @@ func main() {
 		modifyBranch()
 	case config.PrintInfo:
 		printInfo()
-	case config.AddJiraIssueToCurrentBranch:
-		addJiraIssueToCurrentBranch()
+	case config.LinkJiraIssueToCurrentBranch:
+		linkJiraIssueToCurrentBranch()
 	}
 }
 
@@ -97,9 +97,11 @@ func modifyBranch() {
 		return
 	}
 
-	issueKeys, err := git.GetIssueKeysFromBranchName(currentBranchName)
-	if err != nil {
-		printErrorToConsole(err)
+	issueKeys := git.GetIssueKeysFromBranchName(currentBranchName)
+	if len(issueKeys) == 0 {
+		printErrorToConsole(fmt.Errorf(
+			"Branch name '%s' does not contain issue keys with prefix '%s'", currentBranchName, config.GetIssueKeyPrefix(),
+		))
 		return
 	}
 
@@ -127,26 +129,21 @@ func modifyBranch() {
 	printInfoToConsole(string(output))
 }
 
-func addJiraIssueToCurrentBranch() {
+func linkJiraIssueToCurrentBranch() {
 	currentBranchName, err := git.GetCurrentBranchName()
 	if err != nil {
 		printErrorToConsole(err)
 		return
 	}
 
-	issueKeys, err := git.GetIssueKeysFromBranchName(currentBranchName)
-	if err != nil {
-		printErrorToConsole(err)
-		return
-	}
-
+	issueKeys := git.GetIssueKeysFromBranchName(currentBranchName)
 	issueKey := config.GetIssueKey()
 	if stringInSlice(issueKey, issueKeys) {
 		printInfoToConsole(fmt.Sprintf("Jira issue %s already linked to the current branch", issueKey))
 		return
 	}
 
-	updatedBranchName, err := git.AddIssueKeysToBranchName([]string{issueKey}, currentBranchName)
+	updatedBranchName, err := git.PrependIssueKeysToBranchName([]string{issueKey}, currentBranchName)
 	if err != nil {
 		printErrorToConsole(err)
 		return
@@ -168,9 +165,11 @@ func printInfo() {
 		return
 	}
 
-	issueKeys, err := git.GetIssueKeysFromBranchName(currentBranchName)
-	if err != nil {
-		printErrorToConsole(err)
+	issueKeys := git.GetIssueKeysFromBranchName(currentBranchName)
+	if len(issueKeys) == 0 {
+		printErrorToConsole(fmt.Errorf(
+			"Branch name '%s' does not contain issue keys with prefix '%s'", currentBranchName, config.GetIssueKeyPrefix(),
+		))
 		return
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,11 +14,11 @@ type OperationType string
 
 // CheckoutBranch is a holder of operation name
 const (
-	CheckoutBranch              OperationType = "CheckoutBranch"
-	ModifyBranch                OperationType = "ModifyBranch"
-	CheckBranchForNewJiraIssue  OperationType = "CheckBranchForNewJiraIssue"
-	PrintInfo                   OperationType = "PrintInfo"
-	AddJiraIssueToCurrentBranch OperationType = "AddJiraIssueToBranch"
+	CheckoutBranch               OperationType = "CheckoutBranch"
+	ModifyBranch                 OperationType = "ModifyBranch"
+	CheckBranchForNewJiraIssue   OperationType = "CheckBranchForNewJiraIssue"
+	PrintInfo                    OperationType = "PrintInfo"
+	LinkJiraIssueToCurrentBranch OperationType = "LinkJiraIssueToBranch"
 )
 
 // OptionsType is a type for stored app configuration
@@ -51,7 +51,7 @@ func InitAndRequestAdditionalData() error {
 	modifyBranch := flag.Bool("m", false, "Update branch name with Jira issue summary")
 	createIssue := flag.Bool("cj", false, "Create a new Jira issue and switch to the new branch")
 	printIssuesInfo := flag.Bool("info", false, "Print current branch Jira issues information")
-	issueCodeForLinking := flag.Int("ab", 0, "Links Jira Issue to current branch")
+	issueCodeForLinking := flag.Int("lj", 0, "Links Jira Issue to current branch")
 	flag.Parse()
 
 	if *ticketID < 0 {
@@ -65,7 +65,7 @@ func InitAndRequestAdditionalData() error {
 	}
 
 	if *issueCodeForLinking > 0 {
-		Options.Operation = AddJiraIssueToCurrentBranch
+		Options.Operation = LinkJiraIssueToCurrentBranch
 		Options.IssueCode = *issueCodeForLinking
 		return nil
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,10 +14,11 @@ type OperationType string
 
 // CheckoutBranch is a holder of operation name
 const (
-	CheckoutBranch             OperationType = "CheckoutBranch"
-	ModifyBranch               OperationType = "ModifyBranch"
-	CheckBranchForNewJiraIssue OperationType = "CheckBranchForNewJiraIssue"
-	PrintInfo                  OperationType = "PrintInfo"
+	CheckoutBranch              OperationType = "CheckoutBranch"
+	ModifyBranch                OperationType = "ModifyBranch"
+	CheckBranchForNewJiraIssue  OperationType = "CheckBranchForNewJiraIssue"
+	PrintInfo                   OperationType = "PrintInfo"
+	AddJiraIssueToCurrentBranch OperationType = "AddJiraIssueToBranch"
 )
 
 // OptionsType is a type for stored app configuration
@@ -50,6 +51,7 @@ func InitAndRequestAdditionalData() error {
 	modifyBranch := flag.Bool("m", false, "Update branch name with Jira issue summary")
 	createIssue := flag.Bool("cj", false, "Create a new Jira issue and switch to the new branch")
 	printIssuesInfo := flag.Bool("info", false, "Print current branch Jira issues information")
+	issueCodeForLinking := flag.Int("ab", 0, "Links Jira Issue to current branch")
 	flag.Parse()
 
 	if *ticketID < 0 {
@@ -59,6 +61,12 @@ func InitAndRequestAdditionalData() error {
 	if *ticketID > 0 {
 		Options.IssueCode = *ticketID
 		Options.Operation = CheckoutBranch
+		return nil
+	}
+
+	if *issueCodeForLinking > 0 {
+		Options.Operation = AddJiraIssueToCurrentBranch
+		Options.IssueCode = *issueCodeForLinking
 		return nil
 	}
 

--- a/pkg/git/commands.go
+++ b/pkg/git/commands.go
@@ -69,8 +69,8 @@ func CheckoutNewBranch(branchName string) ([]byte, error) {
 	return output, nil
 }
 
-// UpdateBranchName updates current branch name
-func UpdateBranchName(branchName string) ([]byte, error) {
+// UpdateCurrentBranchName updates current branch name
+func UpdateCurrentBranchName(branchName string) ([]byte, error) {
 	cmd := exec.Command("git", "branch", "-m", branchName)
 	output, err := cmd.Output()
 	if err != nil {

--- a/pkg/git/utils.go
+++ b/pkg/git/utils.go
@@ -2,7 +2,6 @@ package git
 
 import (
 	"errors"
-	"fmt"
 	"got/pkg/config"
 	"regexp"
 	"strings"
@@ -27,35 +26,23 @@ func GenerateBranchName(issueKeys []string, summary string) (string, error) {
 	return strings.Join(branchNameSubstrings, config.Options.IssueBranchSeparator), nil
 }
 
-// AddIssueKeysToBranchName add issue keys to branch name
-func AddIssueKeysToBranchName(issueKeys []string, branchName string) (string, error) {
+// PrependIssueKeysToBranchName prepends issue keys to branch name
+func PrependIssueKeysToBranchName(issueKeys []string, branchName string) (string, error) {
 	branchNameSubstrings := append(issueKeys, branchName)
 
 	return strings.Join(branchNameSubstrings, config.Options.IssueBranchSeparator), nil
 }
 
 // GetIssueKeysFromBranchName returns list of Jira issue keys accosiated with current branch
-func GetIssueKeysFromBranchName(branchName string) ([]string, error) {
+func GetIssueKeysFromBranchName(branchName string) []string {
 	substrings := strings.Split(branchName, config.Options.IssueBranchSeparator)
-	if len(substrings) == 0 {
-		return nil, fmt.Errorf(
-			"Branch name '%s' is in wrong format. Is should contain '%s'", branchName, config.Options.IssueBranchSeparator,
-		)
-	}
 
 	issueKeyPrefix := config.GetIssueKeyPrefix()
 	filterFunc := func(substring string) bool {
 		return strings.HasPrefix(substring, issueKeyPrefix)
 	}
 
-	issueKeys := filter(substrings, filterFunc)
-	if len(issueKeys) == 0 {
-		return nil, fmt.Errorf(
-			"Branch name '%s' does not contain issue keys with prefix '%s'", branchName, issueKeyPrefix,
-		)
-	}
-
-	return issueKeys, nil
+	return filter(substrings, filterFunc)
 }
 
 func filter(stringsArr []string, filterFunc func(string) bool) (filteredArr []string) {

--- a/pkg/git/utils.go
+++ b/pkg/git/utils.go
@@ -27,6 +27,13 @@ func GenerateBranchName(issueKeys []string, summary string) (string, error) {
 	return strings.Join(branchNameSubstrings, config.Options.IssueBranchSeparator), nil
 }
 
+// AddIssueKeysToBranchName add issue keys to branch name
+func AddIssueKeysToBranchName(issueKeys []string, branchName string) (string, error) {
+	branchNameSubstrings := append(issueKeys, branchName)
+
+	return strings.Join(branchNameSubstrings, config.Options.IssueBranchSeparator), nil
+}
+
 // GetIssueKeysFromBranchName returns list of Jira issue keys accosiated with current branch
 func GetIssueKeysFromBranchName(branchName string) ([]string, error) {
 	substrings := strings.Split(branchName, config.Options.IssueBranchSeparator)


### PR DESCRIPTION
## Sumary
Current PR adds flag '-lj XXXX' that links Jira issue to the current branch (without validation of Jira issue existence).
Also current PR fixes bug with branch name search by issue code and refactors `git.GetIssueKeysFromBranchName` for better flexibility in further usage


## Checklist
- Checkout new branch `PC-22/test_branch_name`
- execute `got -ab 1234`
- it should update branch name to `PC-1234/test_branch_name`