### PR TITLE
Add -uj flag that allows to remove Jira issue linking from the current branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It helps to reduce the amount of time spent on creating/managing git branches th
 ### List of all supported flags
 - `got -b XXXX` - creates new git branch with the name generated from Jira issue. If the branch already exists (locally or remotely) then it will switch to it.
 - `got -lj XXXX` - links Jira issue to the current branch if not linked already
+- `got -uj XXXX` - unlinks Jira issue from the current branch
 - `got -cj` - creates a new Jira issue and if it succeeds creates new git branch for it
 - `got -m` - modifies Jira issue summary and current branch name
 - `got -info` - prints current branch Jira issues info

--- a/main.go
+++ b/main.go
@@ -25,6 +25,8 @@ func main() {
 		printInfo()
 	case config.LinkJiraIssueToCurrentBranch:
 		linkJiraIssueToCurrentBranch()
+	case config.UnlinkJiraIssueFromCurrentBranch:
+		unlinkJiraIssueFromCurrentBranch()
 	}
 }
 
@@ -155,6 +157,26 @@ func linkJiraIssueToCurrentBranch() {
 		return
 	}
 
+	printInfoToConsole(string(output))
+}
+
+func unlinkJiraIssueFromCurrentBranch() {
+	currentBranchName, err := git.GetCurrentBranchName()
+	if err != nil {
+		printErrorToConsole(err)
+		return
+	}
+
+	issueKey := config.GetIssueKey()
+	updatedBranchName := git.RemoveIssueKeysFromBranchName([]string{issueKey}, currentBranchName)
+
+	output, err := git.UpdateCurrentBranchName(updatedBranchName)
+	if err != nil {
+		printErrorToConsole(err)
+		return
+	}
+
+	printInfoToConsole(fmt.Sprintf("Jira issue '%s' was unlinked from the current branch", issueKey))
 	printInfoToConsole(string(output))
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -14,11 +14,12 @@ type OperationType string
 
 // CheckoutBranch is a holder of operation name
 const (
-	CheckoutBranch               OperationType = "CheckoutBranch"
-	ModifyBranch                 OperationType = "ModifyBranch"
-	CheckBranchForNewJiraIssue   OperationType = "CheckBranchForNewJiraIssue"
-	PrintInfo                    OperationType = "PrintInfo"
-	LinkJiraIssueToCurrentBranch OperationType = "LinkJiraIssueToBranch"
+	CheckoutBranch                   OperationType = "CheckoutBranch"
+	ModifyBranch                     OperationType = "ModifyBranch"
+	CheckBranchForNewJiraIssue       OperationType = "CheckBranchForNewJiraIssue"
+	PrintInfo                        OperationType = "PrintInfo"
+	LinkJiraIssueToCurrentBranch     OperationType = "LinkJiraIssueToCurrentBranch"
+	UnlinkJiraIssueFromCurrentBranch OperationType = "UnlinkJiraIssueFromCurrentBranch"
 )
 
 // OptionsType is a type for stored app configuration
@@ -52,6 +53,7 @@ func InitAndRequestAdditionalData() error {
 	createIssue := flag.Bool("cj", false, "Create a new Jira issue and switch to the new branch")
 	printIssuesInfo := flag.Bool("info", false, "Print current branch Jira issues information")
 	issueCodeForLinking := flag.Int("lj", 0, "Links Jira Issue to current branch")
+	issueCodeForUnlinking := flag.Int("uj", 0, "Unlinks Jira Issue from the current branch")
 	flag.Parse()
 
 	if *ticketID < 0 {
@@ -67,6 +69,12 @@ func InitAndRequestAdditionalData() error {
 	if *issueCodeForLinking > 0 {
 		Options.Operation = LinkJiraIssueToCurrentBranch
 		Options.IssueCode = *issueCodeForLinking
+		return nil
+	}
+
+	if *issueCodeForUnlinking > 0 {
+		Options.Operation = UnlinkJiraIssueFromCurrentBranch
+		Options.IssueCode = *issueCodeForUnlinking
 		return nil
 	}
 

--- a/pkg/git/utils.go
+++ b/pkg/git/utils.go
@@ -33,6 +33,16 @@ func PrependIssueKeysToBranchName(issueKeys []string, branchName string) (string
 	return strings.Join(branchNameSubstrings, config.Options.IssueBranchSeparator), nil
 }
 
+// RemoveIssueKeysFromBranchName remove issue keys from branch name
+func RemoveIssueKeysFromBranchName(issueKeys []string, branchName string) string {
+	substrings := strings.Split(branchName, config.Options.IssueBranchSeparator)
+	for _, issueKey := range issueKeys {
+		substrings = removeElementFromArray(substrings, issueKey)
+	}
+
+	return strings.Join(substrings, config.Options.IssueBranchSeparator)
+}
+
 // GetIssueKeysFromBranchName returns list of Jira issue keys accosiated with current branch
 func GetIssueKeysFromBranchName(branchName string) []string {
 	substrings := strings.Split(branchName, config.Options.IssueBranchSeparator)
@@ -52,4 +62,22 @@ func filter(stringsArr []string, filterFunc func(string) bool) (filteredArr []st
 		}
 	}
 	return
+}
+
+func removeElementFromArray(stringsArr []string, stringToRemove string) (filteredArr []string) {
+	i := findElementInArray(stringsArr, stringToRemove)
+	if i == -1 {
+		return stringsArr
+	}
+
+	return append(stringsArr[:i], stringsArr[i+1:]...)
+}
+
+func findElementInArray(arr []string, stringToSearch string) int {
+	for i, element := range arr {
+		if stringToSearch == element {
+			return i
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
## Summary
Current PR adds '-uj XXXX' flag that allows to remove specified Jira issue code from the branch name
